### PR TITLE
BugFix: Unexpected layout spacing on mobile 

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -14,9 +14,9 @@
     <link rel="icon" sizes="192x192" type="image/png" href="../images/favicon2_01.png">
     <!--css-->
     <link href="css/style.css" rel="stylesheet">
-    <script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
+    <script defer type="text/javascript" src="https://www.google-analytics.com/analytics.js"></script>
     <!--scripts-->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
 </head>
 
@@ -43,22 +43,22 @@
         </ul>
     </header>
 
-    <section class="contact_vid_container">
-        <video class="contact_vid" autoplay playsinline loop="loop" muted="muted">
+    <section class="landing_vid_container">
+        <video class="landing_vid" autoplay playsinline loop="loop" muted="muted">
             <source src="assets/new__vid3.mp4" type="video/mp4">
             <source src="assets/new__vid3.mp4" type="video/ogg"> 
                 Your browser does not support the video tag.
         </video>
     </section>
 
-    <footer class="contact_words_container">
-        <div class="contact_words">
+    <footer class="landing_words_container">
+        <div class="landing_words">
             <a href="mailto:hi@cdtp.site"> hi@cdtp.SITE</a><br>
             <div>010-3929-6303 &nbsp;&nbsp;010-4430-5444</div>
         </div>
     </footer>
 
-    <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-132753072-1"></script>
+    <script defer src="https://www.googletagmanager.com/gtag/js?id=UA-132753072-1"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
 

--- a/course.html
+++ b/course.html
@@ -14,10 +14,10 @@
     <link rel="icon" sizes="192x192" type="image/png" href="../images/favicon2_01.png">
     <!--css-->
     <link href="css/style.css" rel="stylesheet">
-    <script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
+    <script defer type="text/javascript" src="https://www.google-analytics.com/analytics.js"></script>
     <!--scripts-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <script src="https://player.vimeo.com/api/player.js"></script>
+    <script defer src="https://player.vimeo.com/api/player.js"></script>
     <script>
         $(document).ready(function() {
             $(".grid__9").hide();

--- a/css/style.css
+++ b/css/style.css
@@ -52,6 +52,7 @@ a:hover {
 body {
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     font-family: "SharpGrotesk", "GothicA1", sans-serif;
     font-size: 3vw;
     -webkit-font-smoothing: antialiased;
@@ -60,7 +61,7 @@ body {
     line-height: .8em;
     vertical-align: text-bottom;
     width: 100vw;
-    height: 100vh;
+    height: calc(100vh - calc(100vh - 100%));
     background-color: black;
 }
 

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
     <link rel="icon" sizes="192x192" type="image/png" href="../images/favicon2_01.png">
     <!--css-->
     <link href="css/style.css" rel="stylesheet">
-    <script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
+    <script defer type="text/javascript" src="https://www.google-analytics.com/analytics.js"></script>
     <!--scripts-->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
 </head>
 
@@ -57,7 +57,7 @@
         </div>
     </footer>
 
-    <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-132753072-1"></script>
+    <script defer src="https://www.googletagmanager.com/gtag/js?id=UA-132753072-1"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
 


### PR DESCRIPTION
# Description
- Updated `defer` script import 
  - Excepting `jquery` cdn import, because it is needed to use `$(document).ready()` on `course.html`

- Updated class name to **reuse** CSS style code
  - `landing_vid_container`
  - `landing_vid`
  - `landing_words_container`
  - `landing_words`

- Updated body height
  - There is a well-known issue with mobile viewports (maybe you should check this topic)
  - [CSS fix for 100vh in mobile WebKit](https://css-tricks.com/css-fix-for-100vh-in-mobile-webkit/)


# Related issues
- resolve #2
- resolve #3 
